### PR TITLE
Add responsive static landing page for べるフィット

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>べるフィット | やさしい医療フィットネス</title>
+    <meta
+      name="description"
+      content="60代女性のための、やさしい医療フィットネス。おしゃべりから始まる、無理のない運動習慣。"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primaryBlue: '#1F4E79',
+              hoverBlue: '#163A5A',
+              brownAccent: '#6B3E2E',
+              softBg: '#F5F7FA',
+              pureWhite: '#FFFFFF'
+            },
+            fontFamily: {
+              sans: ['Noto Sans JP', 'sans-serif']
+            },
+            borderRadius: {
+              xl: '12px',
+              '2xl': '16px'
+            }
+          }
+        }
+      };
+    </script>
+  </head>
+  <body class="bg-softBg text-slate-800 antialiased">
+    <header class="sticky top-0 z-50 border-b border-slate-200 bg-pureWhite/95 backdrop-blur">
+      <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        <a href="#top" class="text-xl font-bold tracking-wide text-primaryBlue sm:text-2xl">べるフィット</a>
+        <a
+          href="tel:000-0000-0000"
+          class="rounded-xl bg-primaryBlue px-4 py-3 text-base font-medium text-pureWhite transition hover:bg-hoverBlue focus:outline-none focus:ring-4 focus:ring-primaryBlue/30 sm:px-5"
+          aria-label="お電話でお問い合わせ"
+          >お電話はこちら</a
+        >
+      </div>
+    </header>
+
+    <main id="top">
+      <section class="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20 lg:py-24">
+        <div class="rounded-2xl bg-pureWhite p-8 shadow-sm sm:p-10 lg:p-14">
+          <p class="mb-5 text-base font-medium text-brownAccent">やさしい医療フィットネス</p>
+          <h1 class="mb-6 text-3xl font-bold leading-relaxed text-primaryBlue sm:text-4xl lg:text-5xl">
+            この先も、自分の脚で歩いていくために。
+          </h1>
+          <p class="mb-4 text-xl font-medium leading-relaxed text-slate-700 sm:text-2xl">
+            でも、今日はやる気ゼロでも大丈夫です。
+          </p>
+          <p class="mb-8 max-w-3xl text-lg leading-loose text-slate-600 sm:text-xl">
+            60代女性のための、やさしい医療フィットネス。おしゃべりから始まる、無理のない運動習慣。
+          </p>
+          <div class="flex flex-col gap-4 sm:flex-row">
+            <a
+              href="tel:000-0000-0000"
+              class="inline-flex min-h-12 items-center justify-center rounded-xl bg-primaryBlue px-7 py-4 text-lg font-medium text-pureWhite transition hover:bg-hoverBlue focus:outline-none focus:ring-4 focus:ring-primaryBlue/30"
+              >お電話で体験予約</a
+            >
+            <a
+              href="#contact"
+              class="inline-flex min-h-12 items-center justify-center rounded-xl border-2 border-primaryBlue bg-pureWhite px-7 py-4 text-lg font-medium text-primaryBlue transition hover:bg-slate-50 focus:outline-none focus:ring-4 focus:ring-primaryBlue/20"
+              >フォームから予約</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="bg-softBg py-14 sm:py-16">
+        <div class="mx-auto max-w-6xl px-4 sm:px-6">
+          <div class="rounded-2xl bg-pureWhite p-8 sm:p-10">
+            <h2 class="mb-6 text-2xl font-bold text-primaryBlue sm:text-3xl">こんなお悩みありませんか？</h2>
+            <ul class="space-y-4 text-lg leading-relaxed sm:text-xl">
+              <li class="rounded-xl bg-softBg px-5 py-4">最近、階段がつらい</li>
+              <li class="rounded-xl bg-softBg px-5 py-4">将来歩けなくなるのが不安</li>
+              <li class="rounded-xl bg-softBg px-5 py-4">ジムは怖い</li>
+              <li class="rounded-xl bg-softBg px-5 py-4">運動が続かない</li>
+              <li class="rounded-xl bg-softBg px-5 py-4">家にいる時間が増えた</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="mx-auto max-w-6xl px-4 py-14 sm:px-6 sm:py-16">
+        <h2 class="mb-8 text-2xl font-bold text-primaryBlue sm:text-3xl">べるフィットの考え方</h2>
+        <ul class="grid gap-4 sm:grid-cols-2">
+          <li class="rounded-2xl bg-pureWhite p-6 text-lg leading-relaxed">運動目的でも、おしゃべり目的でも歓迎</li>
+          <li class="rounded-2xl bg-pureWhite p-6 text-lg leading-relaxed">家から出ることが最大の目的でも大丈夫</li>
+          <li class="rounded-2xl bg-pureWhite p-6 text-lg leading-relaxed">やる気ゼロでも問題ありません</li>
+          <li class="rounded-2xl bg-pureWhite p-6 text-lg leading-relaxed">話していたら自然に動いていた</li>
+          <li class="rounded-2xl bg-pureWhite p-6 text-lg leading-relaxed sm:col-span-2">また来たいと思える場所に</li>
+        </ul>
+      </section>
+
+      <section class="bg-pureWhite py-14 sm:py-16">
+        <div class="mx-auto max-w-6xl px-4 sm:px-6">
+          <h2 class="mb-8 text-2xl font-bold text-primaryBlue sm:text-3xl">なぜ安心なのか</h2>
+          <ul class="space-y-4 text-lg leading-relaxed sm:text-xl">
+            <li class="rounded-xl border border-slate-200 px-5 py-4">医療系国家資格者が運営</li>
+            <li class="rounded-xl border border-slate-200 px-5 py-4">無理な負荷はかけません</li>
+            <li class="rounded-xl border border-slate-200 px-5 py-4">体調に合わせて調整</li>
+            <li class="rounded-xl border border-slate-200 px-5 py-4">小さな変化にも気づく体制</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="mx-auto max-w-6xl px-4 py-14 sm:px-6 sm:py-16">
+        <h2 class="mb-8 text-2xl font-bold text-primaryBlue sm:text-3xl">1日の流れ</h2>
+        <ol class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          <li class="rounded-2xl bg-pureWhite p-6">
+            <p class="mb-3 text-sm font-semibold text-brownAccent">STEP 1</p>
+            <p class="text-lg leading-relaxed">ご来館・体調チェック</p>
+          </li>
+          <li class="rounded-2xl bg-pureWhite p-6">
+            <p class="mb-3 text-sm font-semibold text-brownAccent">STEP 2</p>
+            <p class="text-lg leading-relaxed">おしゃべりしながら準備運動</p>
+          </li>
+          <li class="rounded-2xl bg-pureWhite p-6">
+            <p class="mb-3 text-sm font-semibold text-brownAccent">STEP 3</p>
+            <p class="text-lg leading-relaxed">やさしい筋力・バランストレーニング</p>
+          </li>
+          <li class="rounded-2xl bg-pureWhite p-6">
+            <p class="mb-3 text-sm font-semibold text-brownAccent">STEP 4</p>
+            <p class="text-lg leading-relaxed">休憩と水分補給</p>
+          </li>
+          <li class="rounded-2xl bg-pureWhite p-6">
+            <p class="mb-3 text-sm font-semibold text-brownAccent">STEP 5</p>
+            <p class="text-lg leading-relaxed">体調に合わせた軽運動</p>
+          </li>
+          <li class="rounded-2xl bg-pureWhite p-6">
+            <p class="mb-3 text-sm font-semibold text-brownAccent">STEP 6</p>
+            <p class="text-lg leading-relaxed">振り返り・次回のご案内</p>
+          </li>
+        </ol>
+      </section>
+
+      <section class="bg-pureWhite py-14 sm:py-16">
+        <div class="mx-auto max-w-4xl px-4 sm:px-6">
+          <h2 class="mb-8 text-2xl font-bold text-primaryBlue sm:text-3xl">よくあるご質問</h2>
+          <div class="space-y-4" id="faq">
+            <details class="group rounded-xl border border-slate-200 bg-softBg p-5" open>
+              <summary class="cursor-pointer list-none text-lg font-medium leading-relaxed">持病があっても大丈夫？</summary>
+              <p class="mt-4 text-base leading-loose text-slate-600">医療系国家資格者が体調を確認しながら対応します。まずはお気軽にご相談ください。</p>
+            </details>
+            <details class="group rounded-xl border border-slate-200 bg-softBg p-5">
+              <summary class="cursor-pointer list-none text-lg font-medium leading-relaxed">運動が苦手でも大丈夫？</summary>
+              <p class="mt-4 text-base leading-loose text-slate-600">もちろんです。話すことから始めて、できる範囲でゆっくり進めます。</p>
+            </details>
+            <details class="group rounded-xl border border-slate-200 bg-softBg p-5">
+              <summary class="cursor-pointer list-none text-lg font-medium leading-relaxed">無理に頑張らされませんか？</summary>
+              <p class="mt-4 text-base leading-loose text-slate-600">無理な負荷はかけません。体調と気分に合わせて内容を調整します。</p>
+            </details>
+            <details class="group rounded-xl border border-slate-200 bg-softBg p-5">
+              <summary class="cursor-pointer list-none text-lg font-medium leading-relaxed">体験だけでもいいですか？</summary>
+              <p class="mt-4 text-base leading-loose text-slate-600">体験だけでも大歓迎です。雰囲気を見てからご検討いただけます。</p>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-20">
+        <div class="rounded-2xl bg-primaryBlue px-6 py-12 text-center text-pureWhite sm:px-10">
+          <h2 class="mb-4 text-2xl font-bold leading-relaxed sm:text-4xl">まずは、気軽なお電話から。</h2>
+          <p class="mb-8 text-lg leading-loose text-slate-100 sm:text-xl">
+            「少し話を聞いてみたい」だけでも大丈夫です。
+          </p>
+          <a
+            href="tel:000-0000-0000"
+            class="inline-flex min-h-12 items-center justify-center rounded-xl bg-pureWhite px-8 py-4 text-xl font-bold text-primaryBlue transition hover:bg-slate-100 focus:outline-none focus:ring-4 focus:ring-pureWhite/40"
+            >お電話で体験予約する</a
+          >
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-slate-900 py-10 text-slate-200">
+      <div class="mx-auto grid max-w-6xl gap-4 px-4 text-base sm:px-6 sm:text-lg">
+        <p>住所：〒000-0000 東京都〇〇区〇〇 0-0-0</p>
+        <p>電話番号：<a class="underline hover:text-white" href="tel:000-0000-0000">000-0000-0000</a></p>
+        <p>営業時間：平日 9:00〜18:00</p>
+        <p class="pt-2 text-sm text-slate-400">© 2026 べるフィット All Rights Reserved.</p>
+      </div>
+    </footer>
+
+    <script>
+      document.querySelectorAll('#faq details').forEach((detail) => {
+        detail.addEventListener('toggle', () => {
+          if (detail.open) {
+            document.querySelectorAll('#faq details').forEach((other) => {
+              if (other !== detail) other.open = false;
+            });
+          }
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single-file, mobile-first landing page for the Japanese medical fitness facility “べるフィット” with senior-friendly accessibility and a calm, medical-warmth tone.
- Use lightweight tech (single HTML file, Tailwind via CDN, no build tools) and the requested Azzurro e Marrone color palette and `Noto Sans JP` typography.

### Description
- Added `index.html` containing a complete responsive layout, Tailwind CDN usage and an inline `tailwind.config` that defines the custom colors, fonts, and rounded radii.
- Implemented a sticky header with a persistent phone CTA using `tel:` links, a hero with primary/secondary CTAs, empathy/problem, philosophy, safety, daily flow (steps 1–6), FAQ accordion, final CTA and footer placeholders.
- Included a small accessible JS behavior to make the FAQ act like a single-open accordion using `<details>` and `toggle` handling.
- Applied accessibility-focused choices such as large font sizes, high-contrast colors, generous spacing and large tappable buttons for senior usability.

### Testing
- Served the page locally using `python3 -m http.server 4173 --bind 0.0.0.0` and verified the site responded successfully.
- Captured a full-page rendering screenshot via an automated Playwright script to confirm layout and responsive styling rendered correctly, which succeeded.
- Confirmed the repository now contains the ready-to-use `index.html` file and automated checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69941312977483219b56ac5585cba1bc)