### PR TITLE
Create refined premium landing page for べるフィット

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>べるフィット | 医療連携型メディカルフィットネス</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: '#1F4E79',
+              primaryDeep: '#163A5A',
+              accent: '#6B3E2E',
+              softBg: '#F5F7FA',
+              warmTint: '#EEF2F6'
+            },
+            maxWidth: {
+              content: '1100px'
+            },
+            borderRadius: {
+              soft: '16px'
+            },
+            boxShadow: {
+              premium: '0 10px 30px rgba(22, 58, 90, 0.10)',
+              elevated: '0 20px 45px rgba(22, 58, 90, 0.14)'
+            }
+          }
+        }
+      };
+    </script>
+    <style>
+      :root {
+        --primary: #1F4E79;
+        --primary-deep: #163A5A;
+        --accent: #6B3E2E;
+        --soft-bg: #F5F7FA;
+        --warm-tint: #EEF2F6;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        font-family: 'Noto Sans JP', sans-serif;
+        background: var(--soft-bg);
+        color: #203044;
+        font-size: 17px;
+        line-height: 1.85;
+        letter-spacing: 0.02em;
+      }
+
+      .hero-gradient {
+        background: linear-gradient(180deg, #ffffff 0%, #f8fbff 40%, #edf3fa 100%);
+      }
+
+      .section-divider {
+        width: 96px;
+        height: 1px;
+        background: rgba(107, 62, 46, 0.45);
+      }
+
+      .premium-card {
+        border-radius: 16px;
+        background: #ffffff;
+        box-shadow: 0 10px 30px rgba(22, 58, 90, 0.08);
+        transition: transform 0.4s ease, box-shadow 0.4s ease;
+      }
+
+      .premium-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 20px 45px rgba(22, 58, 90, 0.14);
+      }
+
+      .cta {
+        transition: transform 0.35s ease, box-shadow 0.35s ease, background-color 0.35s ease,
+          color 0.35s ease;
+      }
+
+      .cta:hover {
+        transform: scale(1.03);
+      }
+
+      .faq-content {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.45s ease;
+      }
+
+      .faq-item.open .faq-content {
+        max-height: 220px;
+      }
+
+      .faq-item .indicator {
+        transition: transform 0.35s ease;
+      }
+
+      .faq-item.open .indicator {
+        transform: rotate(45deg);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="hero-gradient">
+      <div class="mx-auto max-w-content px-6 py-8 md:px-10">
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm tracking-[0.25em] text-accent">MEDICAL FITNESS</p>
+            <h1 class="text-2xl font-semibold tracking-[0.15em] text-primary">べるフィット</h1>
+          </div>
+          <a
+            href="#contact"
+            class="cta rounded-soft border border-primary px-5 py-2 text-sm font-medium text-primary hover:bg-primary hover:text-white"
+            >見学予約</a
+          >
+        </div>
+      </div>
+
+      <section class="mx-auto max-w-content px-6 pb-24 pt-12 md:px-10 md:pt-16">
+        <div class="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+          <div>
+            <p class="mb-5 text-sm tracking-[0.3em] text-accent">TRUST × WARMTH × BALANCE</p>
+            <h2 class="mb-8 text-4xl font-medium leading-[1.35] tracking-[0.08em] text-primary md:text-5xl">
+              身体と医療を、
+              <br class="hidden md:block" />
+              穏やかにつなぐ日常へ。
+            </h2>
+            <p class="max-w-xl text-[17px] text-slate-700 md:text-[19px]">
+              べるフィットは、医療知見に基づいた評価とコンディショニングで、無理のない改善を支えるメディカルフィットネスです。落ち着いた空間で、安心して継続できる時間を提供します。
+            </p>
+            <div class="mt-10 flex flex-wrap gap-4">
+              <a
+                href="#contact"
+                class="cta rounded-soft bg-primary px-8 py-4 text-base font-medium text-white shadow-premium hover:bg-primaryDeep"
+                >無料カウンセリング</a
+              >
+              <a
+                href="#programs"
+                class="cta rounded-soft border border-accent px-8 py-4 text-base font-medium text-accent hover:bg-accent hover:text-white"
+                >プログラムを見る</a
+              >
+            </div>
+          </div>
+
+          <div class="premium-card p-8 md:p-10">
+            <div
+              class="h-[340px] rounded-soft border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-[#e7eef6] p-8 md:h-[420px]"
+            >
+              <div class="flex h-full flex-col justify-between">
+                <div>
+                  <p class="text-xs tracking-[0.28em] text-accent">CLINICAL QUALITY</p>
+                  <h3 class="mt-3 text-2xl font-medium leading-relaxed text-primary">
+                    からだの状態を
+                    <br />
+                    丁寧に可視化する設計
+                  </h3>
+                </div>
+                <div class="space-y-4">
+                  <div class="h-px w-full bg-slate-300"></div>
+                  <p class="text-sm text-slate-600">
+                    姿勢・関節可動・呼吸パターンを評価し、個別に最適化したプランを提案します。
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </header>
+
+    <main>
+      <section id="concept" class="py-24">
+        <div class="mx-auto max-w-content px-6 md:px-10">
+          <div class="section-divider mb-8"></div>
+          <h3 class="mb-6 text-3xl font-medium tracking-[0.05em] text-primary md:text-4xl">
+            べるフィットの考え方
+          </h3>
+          <p class="max-w-3xl text-slate-700 md:text-[19px]">
+            目指すのは「鍛えること」ではなく「整えること」。医療職との連携を前提に、生活背景や既往歴に配慮したプログラムを設計し、痛みや不調を抱える方にも静かに寄り添います。
+          </p>
+        </div>
+      </section>
+
+      <section id="programs" class="bg-warmTint py-24">
+        <div class="mx-auto max-w-content px-6 md:px-10">
+          <div class="section-divider mb-8"></div>
+          <h3 class="mb-14 text-3xl font-medium tracking-[0.05em] text-primary md:text-4xl">提供プログラム</h3>
+          <div class="grid gap-8 md:grid-cols-3">
+            <article class="premium-card p-8">
+              <h4 class="mb-4 text-xl font-medium text-primary">医療評価ベース初期プラン</h4>
+              <p class="text-slate-700">
+                関節・筋機能・姿勢の評価をもとに、現在地を明確化。安全性と継続性を重視した導入プログラムです。
+              </p>
+            </article>
+            <article class="premium-card p-8">
+              <h4 class="mb-4 text-xl font-medium text-primary">慢性不調コンディショニング</h4>
+              <p class="text-slate-700">
+                肩・腰・膝などの慢性的な違和感に対し、負担を抑えながら可動域と安定性を回復させます。
+              </p>
+            </article>
+            <article class="premium-card p-8">
+              <h4 class="mb-4 text-xl font-medium text-primary">予防メンテナンス継続コース</h4>
+              <p class="text-slate-700">
+                日常動作の質を高めるための定期セッション。将来の不調リスクを抑える習慣形成を支援します。
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-24">
+        <div class="mx-auto max-w-content px-6 md:px-10">
+          <div class="section-divider mb-8"></div>
+          <h3 class="mb-14 text-3xl font-medium tracking-[0.05em] text-primary md:text-4xl">よくあるご質問</h3>
+          <div class="space-y-4">
+            <div class="faq-item premium-card">
+              <button class="faq-trigger flex w-full items-center justify-between px-7 py-6 text-left">
+                <span class="text-lg font-medium text-primary">運動経験がなくても利用できますか？</span>
+                <span class="indicator text-2xl font-light text-accent">+</span>
+              </button>
+              <div class="faq-content px-7 pb-6">
+                <p class="text-slate-700">
+                  はい。評価結果に応じて強度を細かく調整するため、運動習慣がない方や体力に不安がある方でも安心して始められます。
+                </p>
+              </div>
+            </div>
+
+            <div class="faq-item premium-card">
+              <button class="faq-trigger flex w-full items-center justify-between px-7 py-6 text-left">
+                <span class="text-lg font-medium text-primary">医療機関との連携はありますか？</span>
+                <span class="indicator text-2xl font-light text-accent">+</span>
+              </button>
+              <div class="faq-content px-7 pb-6">
+                <p class="text-slate-700">
+                  提携医療職の監修のもと、必要に応じて受診推奨や情報共有を行います。医療的な安全性を重視した運営体制です。
+                </p>
+              </div>
+            </div>
+
+            <div class="faq-item premium-card">
+              <button class="faq-trigger flex w-full items-center justify-between px-7 py-6 text-left">
+                <span class="text-lg font-medium text-primary">どのくらいの頻度で通うのが理想ですか？</span>
+                <span class="indicator text-2xl font-light text-accent">+</span>
+              </button>
+              <div class="faq-content px-7 pb-6">
+                <p class="text-slate-700">
+                  初期は週1回、その後は月2回程度のメンテナンスを推奨しています。生活負担を抑えつつ、長期的な変化を目指します。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="bg-white py-24">
+        <div class="mx-auto max-w-content px-6 md:px-10">
+          <div class="premium-card p-10 md:p-14">
+            <div class="section-divider mb-8"></div>
+            <h3 class="mb-6 text-3xl font-medium tracking-[0.05em] text-primary md:text-4xl">静かな一歩を、ここから。</h3>
+            <p class="max-w-2xl text-slate-700 md:text-[19px]">
+              施設見学と初回カウンセリングは予約制で承っています。落ち着いた空間で、現在のお悩みや目標を丁寧に伺います。
+            </p>
+            <div class="mt-10 flex flex-wrap gap-4">
+              <a
+                href="#"
+                class="cta rounded-soft bg-primary px-8 py-4 text-base font-medium text-white shadow-premium hover:bg-primaryDeep"
+                >見学を予約する</a
+              >
+              <a
+                href="#"
+                class="cta rounded-soft border border-accent px-8 py-4 text-base font-medium text-accent hover:bg-accent hover:text-white"
+                >お問い合わせ</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-primaryDeep py-12 text-white">
+      <div class="mx-auto flex max-w-content flex-col gap-6 px-6 md:flex-row md:items-end md:justify-between md:px-10">
+        <div>
+          <p class="text-xs tracking-[0.25em] text-slate-300">MEDICAL FITNESS BRAND</p>
+          <p class="mt-2 text-2xl font-medium tracking-[0.12em]">べるフィット</p>
+        </div>
+        <p class="text-sm text-slate-300">© 2026 べるフィット All Rights Reserved.</p>
+      </div>
+    </footer>
+
+    <script>
+      document.querySelectorAll('.faq-trigger').forEach((button) => {
+        button.addEventListener('click', () => {
+          const item = button.parentElement;
+          const isOpen = item.classList.contains('open');
+
+          document.querySelectorAll('.faq-item').forEach((el) => el.classList.remove('open'));
+          if (!isOpen) item.classList.add('open');
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Deliver a single-file, high-end landing page for the Japanese medical-fitness brand “べるフィット” that feels elegant, calm, medically trustworthy and warm without looking like a gym template.
- Constrain the implementation to a responsive, framework-free HTML file using Tailwind CDN plus focused custom CSS for refined visual language and accessibility.

### Description
- Added a single `index.html` file implementing the requested Azzurro e Marrone palette, `Noto Sans JP` typography, a centered `max-width: 1100px` layout, generous vertical rhythm, subtle gradients, and rounded 16px corners.
- Built a responsive two-column hero (left copy, right abstract visual card), premium cards with subtle shadows and hover elevation, refined primary/secondary CTA styles with smooth hover scale, and thin brown section dividers.
- Implemented an animated FAQ accordion with minimal inline JavaScript for smooth open/close transitions, and a deep-blue footer with high-contrast white text.
- Included tailored custom CSS variables and Tailwind `tailwind.config` extensions to ensure consistent color tokens, shadows, radii, and accessibility-minded type scale.

### Testing
- Served the site locally with `python3 -m http.server 4173 --directory /workspace/homepage` and verified the page responded successfully (HTTP 200).
- Ran a Playwright script to navigate to `http://127.0.0.1:4173/index.html` and capture a full-page screenshot (`artifacts/belfit-landing.png`), which completed successfully.
- Performed a basic static inspection of `index.html` to confirm the presence of the Tailwind CDN, `Noto Sans JP` link, custom CSS, hero, programs, FAQ accordion, contact section, and footer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699421f7425c8321b8f71bf6efefb2af)