### PR TITLE
fix(top): 通い方カードの高さずれを解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@
             <a href="services/fitness/night/index.html" class="card card-hover way-card" style="text-decoration: none; color: inherit; display: flex; flex-direction: column; padding: 0; overflow: hidden;">
               <div style="aspect-ratio: 4 / 3; background-color: var(--color-border); position: relative;">
                 <span class="way-card__num">01</span>
-                <img src="images/photos/fitness-night.webp" alt="夜間・週末に運動するナイト会員の利用イメージ" style="width: 100%; height: 100%; object-fit: cover;" loading="lazy" />
+                <img src="images/photos/fitness-night.webp" alt="夜間・週末に運動するナイト会員の利用イメージ" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" loading="lazy" />
               </div>
               <div style="padding: var(--space-xl); display: flex; flex-direction: column; flex: 1;">
                 <div style="margin-bottom: var(--space-sm); font-size: 0.85rem; color: var(--color-primary); font-weight: bold;">ナイト会員</div>
@@ -413,7 +413,7 @@
             <a href="services/fitness/seed/index.html" class="card card-hover way-card" style="text-decoration: none; color: inherit; display: flex; flex-direction: column; padding: 0; overflow: hidden;">
               <div style="aspect-ratio: 4 / 3; background-color: var(--color-border); position: relative;">
                 <span class="way-card__num">02</span>
-                <img src="images/photos/fitness-main-real.webp" alt="女性同士で運動と会話を楽しむシードの利用イメージ" style="width: 100%; height: 100%; object-fit: cover;" loading="lazy" />
+                <img src="images/photos/fitness-main-real.webp" alt="女性同士で運動と会話を楽しむシードの利用イメージ" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" loading="lazy" />
               </div>
               <div style="padding: var(--space-xl); display: flex; flex-direction: column; flex: 1;">
                 <div style="margin-bottom: var(--space-sm); font-size: 0.85rem; color: var(--color-primary); font-weight: bold;">シード</div>
@@ -427,7 +427,7 @@
             <a href="services/leaf/index.html" class="card card-hover way-card" style="text-decoration: none; color: inherit; display: flex; flex-direction: column; padding: 0; overflow: hidden;">
               <div style="aspect-ratio: 4 / 3; background-color: var(--color-border); position: relative;">
                 <span class="way-card__num">03</span>
-                <img src="images/photos/cases-01-rehab.webp" alt="施設内でスタッフの支えを受けながら歩行運動をするご利用者" style="width: 100%; height: 100%; object-fit: cover;" loading="lazy" />
+                <img src="images/photos/cases-01-rehab.webp" alt="施設内でスタッフの支えを受けながら歩行運動をするご利用者" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;" loading="lazy" />
               </div>
               <div style="padding: var(--space-xl); display: flex; flex-direction: column; flex: 1;">
                 <div style="margin-bottom: var(--space-sm); font-size: 0.85rem; color: #1f7a35; font-weight: bold;">保険が使えるジム（リーフ）</div>


### PR DESCRIPTION
シード枠の縦長写真がカードの枠を押し広げていた問題の修正。3枚とも画像を絶対配置にし、縦横比によらず4:3の枠に収まるようにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)